### PR TITLE
feat: Add Aisle JIT security scan workflow

### DIFF
--- a/.github/workflows/aisle-jit-scan.yml
+++ b/.github/workflows/aisle-jit-scan.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: productboard/shared-workflows/.github/actions/jit-scan@main
+      - uses: productboard/shared-workflows/.github/actions/jit-scan@049662c75ef011f3165aef8e32d9c4446d409da0 # main
         with:
           api_token: ${{ secrets.AISLE_API_TOKEN }}
           api_url:   ${{ secrets.AISLE_API_URL }}

--- a/.github/workflows/aisle-jit-scan.yml
+++ b/.github/workflows/aisle-jit-scan.yml
@@ -1,0 +1,35 @@
+name: Aisle JIT security scan
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aisle-jit-scan-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  aisle-scan:
+    name: Aisle security scan
+    runs-on: pb-2c-4g
+    timeout-minutes: 15
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: productboard/shared-workflows/.github/actions/jit-scan@main
+        with:
+          api_token: ${{ secrets.AISLE_API_TOKEN }}
+          api_url:   ${{ secrets.AISLE_API_URL }}
+          scan_types: sast,sca,licenses
+          fail_on_findings: false


### PR DESCRIPTION
## Summary

Adds the Aisle JIT security scan GitHub Actions workflow.

This workflow:
- Runs on every merged PR to the default branch
- Performs SAST, SCA, and license scanning via the Aisle security platform
- Uses the shared `productboard/shared-workflows` action
- Requires `AISLE_API_TOKEN` and `AISLE_API_URL` secrets (already configured org-wide)

This mirrors the workflow already in place in [pb-kafka](https://github.com/productboard/pb-kafka/blob/master/.github/workflows/aisle-jit-scan.yml).

---
🤖 Automated PR created by Aisle security team